### PR TITLE
refactor provider에 따른 유저 정보 생성 빙식 수정

### DIFF
--- a/src/main/java/com/wdw/wdw/config/oauth/provider/UserInfoFactory.java
+++ b/src/main/java/com/wdw/wdw/config/oauth/provider/UserInfoFactory.java
@@ -1,0 +1,10 @@
+package com.wdw.wdw.config.oauth.provider;
+
+import com.wdw.wdw.exception.InvalidProviderType;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+
+import java.util.Map;
+
+public interface UserInfoFactory {
+    public OAuth2UserInfo makeUserInfo(OAuth2UserRequest userRequest, Map<String, Object> map) throws InvalidProviderType;
+}

--- a/src/main/java/com/wdw/wdw/config/oauth/provider/UserInfoFactoryImpl.java
+++ b/src/main/java/com/wdw/wdw/config/oauth/provider/UserInfoFactoryImpl.java
@@ -1,0 +1,19 @@
+package com.wdw.wdw.config.oauth.provider;
+
+import com.wdw.wdw.exception.InvalidProviderType;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Map;
+
+public class UserInfoFactoryImpl implements UserInfoFactory{
+    @Override
+    public OAuth2UserInfo makeUserInfo(OAuth2UserRequest userRequest, Map<String, Object> attributes) throws InvalidProviderType {
+        switch (userRequest.getClientRegistration().getRegistrationId()) {
+            case "google":
+                return new GoogleUserInfo(attributes);
+            default:
+                throw new InvalidProviderType();
+        }
+    }
+}

--- a/src/main/java/com/wdw/wdw/exception/InvalidProviderType.java
+++ b/src/main/java/com/wdw/wdw/exception/InvalidProviderType.java
@@ -1,0 +1,4 @@
+package com.wdw.wdw.exception;
+
+public class InvalidProviderType extends Exception{
+}


### PR DESCRIPTION
기존 provider에 따른 유저 정보 생성시 if else 문이 너무 많아 OCP 위배와 코드가 복잡해 지는 문제 해결