### PR TITLE
refactor:BadgeType 수정

### DIFF
--- a/src/main/java/com/wdw/wdw/domain/BadgeType.java
+++ b/src/main/java/com/wdw/wdw/domain/BadgeType.java
@@ -17,5 +17,7 @@ public enum BadgeType {
     private Integer consecutiveDay;
 
     BadgeType(Integer intakeOfSum, Integer consecutiveDay) {
+        this.intakeOfSum = intakeOfSum;
+        this.consecutiveDay = consecutiveDay;
     }
 }


### PR DESCRIPTION
api/v1/record/add 수행 시에 addAchievement에서 NullPointerException이 발생

코드 점검하는 과정에서 ex) BadgeType.SUM_GOLD.getIntakeOfSum() 이 null 값으로 반환되길래

BadgeType Enum 생성자 수정하니 null 해결.....
근본적인 이유에 대해서는 추가적으로 조사해서 Issue에 남길게요
아시는 분 알려주십샤....그라샤....